### PR TITLE
Update Plugin.php to correct getPluginName()

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -62,7 +62,7 @@ class Plugin extends Base
 
     public function getPluginName()
     {
-        return 'Subtaskdate';
+        return 'Subtask Due Date';
     }
 
     public function getPluginDescription()


### PR DESCRIPTION
Plugin does not correctly prompt for updating in Kanboard Plugin Directory. getPluginName() must match the name in https://kanboard.org/plugins.json

This change should allow the Plugin Directory to correctly identify whether Subtask Due Date needs an update or is currently up to date in the users installation.